### PR TITLE
Fix loading Disqus comments on https

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -15,7 +15,7 @@ $body$
 
     (function() {
        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-       dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
     </script>


### PR DESCRIPTION
This enables Disqus comments in https://trofi.github.io/ by loading Disqus js using 
same protocol as the document, instead of http only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trofi/trofi.github.io.gen/1)
<!-- Reviewable:end -->
