### PR TITLE
Fit content to body width

### DIFF
--- a/css/code.css
+++ b/css/code.css
@@ -3,6 +3,10 @@ pre {
     padding: 0.5em 0 0.5em 0.5em;
     border-left: 0.3em solid #bbbbbb;
 }
+pre > code {
+    display: block;
+    overflow-x: auto;
+}
 
 /* Used for both `inline` and ```block``` code. */
 code {

--- a/css/default.css
+++ b/css/default.css
@@ -10,6 +10,12 @@ body {
     max-width: 72ch;
 }
 
+img {
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
+}
+
 /* mobile phones */
 @media (max-width: 1000px) {
     body {


### PR DESCRIPTION
I've noticed that some posts look kinda off, especially so on mobile devices:

  <img src="https://user-images.githubusercontent.com/765790/209005819-8c6b3740-076f-4499-845d-47662850f96a.jpg" width=320/>

There are at least two things that contributes to it: unwrapped code lines and images overspilling their containers. That's explainable as they are both inline elements (`img` is a replaceable inline element, but nonetheless) and parent width constraints can't do much to them 🤔 

So, after the fix pages look like this:

- Notice that images are fitted to the body width. Dunno whether it's okay to set those properties on the global level tho 🙈 

  <img src="https://user-images.githubusercontent.com/765790/209006632-0983e49e-8d2a-4455-ba8d-efe13c175cd2.jpg" width=320/>p

- Code blocks are scrollable and constrained by the body width:

  <img src="https://user-images.githubusercontent.com/765790/209006643-c5a95189-cd53-4dfb-b349-2d19f8bb02f9.jpg" width=320/>


