### PR TITLE
Prevent small images from stretching

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -11,9 +11,8 @@ body {
 }
 
 img {
-    height: 100%;
-    width: 100%;
-    object-fit: contain;
+    max-width: 100%;
+    height: auto;
 }
 
 /* mobile phones */


### PR DESCRIPTION
Returning to my comment from https://github.com/trofi/trofi.github.io.gen/pull/7:

> Notice that images are fitted to the body width. Dunno whether it's okay to set those properties on the global level tho 🙈

Well, turns out it forces small images to stretch to parent width. Here are more mild rules that constraint max image width, but shouldn't stretch small images 🙇 